### PR TITLE
Mark the javascript example as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 api-client-javascript
 =====================
 
+| Deprecated |
+|--------------------|
+| This example is deprecated. The Google Genomics v1beta2 API is scheduled for turndown on August 15, 2016. When the API is turned down, this example will cease to function. |
+| For an example of accessing the Google Genomics v1 API from Javascript, see the [Getting Started with the API](https://github.com/googlegenomics/getting-started-with-the-api/) repository. |
+
 ## Getting started
 
 There are html and js files in this repository.


### PR DESCRIPTION
Include a pointer to the new javascript Getting Started example.